### PR TITLE
chore: upgrade tree-sitter Rust dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tree-sitter-bicep"
 description = "Bicep grammar for tree-sitter"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Amaan Qureshi <amaanq12@gmail.com>"]
 license = "MIT"
 readme = "bindings/rust/README.md"
-keywords = ["incremental", "parsing", "bicep"]
+keywords = ["incremental", "parsing", "tree-sitter", "bicep"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/amaanq/tree-sitter-bicep"
 edition = "2021"
@@ -18,7 +18,7 @@ include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "~0.20.10"
+tree-sitter = ">=0.21.0"
 
 [build-dependencies]
 cc = "1.0"

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -8,22 +8,28 @@ way.)
 
 ```toml
 [dependencies]
-tree-sitter = "~0.20.3"
-tree-sitter-bicep = "1.0.1"
+tree-sitter = ">=0.21"
+tree-sitter-bicep = "1.1.0"
 ```
 
 Typically, you will use the [language][language func] function to add this
 grammar to a tree-sitter [Parser][], and then use the parser to parse some code:
 
 ```rust
-let code = r#"
-    fn double(x: i32) -> i32 {
-        x * 2
-    }
-"#;
-let mut parser = Parser::new();
-parser.set_language(tree_sitter_bicep::language()).expect("Error loading Bicep grammar");
-let parsed = parser.parse(code, None);
+let code = "
+resource mystore 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: 'mystorageaccount'
+  location: 'westeurope'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+}
+";
+let mut parser = tree_sitter::Parser::new();
+parser.set_language(&tree_sitter_bicep::language()).expect("Error loading Bicep grammar");
+let tree = parser.parse(code, None).unwrap();
+assert!(!tree.root_node().has_error());
 ```
 
 If you have any questions, please reach out to us in the [tree-sitter

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -2,18 +2,21 @@ fn main() {
     let src_dir = std::path::Path::new("src");
 
     let mut c_config = cc::Build::new();
-    c_config.include(src_dir);
     c_config
-        .flag_if_supported("-Wno-unused-parameter")
-        .flag_if_supported("-Wno-unused-but-set-variable")
-        .flag_if_supported("-Wno-trigraphs");
+        .std("c11")
+        .include(src_dir)
+        .flag_if_supported("-Wno-unused-parameter");
+
+    #[cfg(target_env = "msvc")]
+    c_config.flag("-utf-8");
+
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 
     let scanner_path = src_dir.join("scanner.c");
     c_config.file(&scanner_path);
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
 
-    c_config.compile("parser");
-    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+    c_config.compile("tree-sitter-bicep");
 }

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -4,10 +4,20 @@
 //! tree-sitter [Parser][], and then use the parser to parse some code:
 //!
 //! ```
-//! let code = "";
+//! let code = "
+//! resource mystore 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+//!   name: 'mystorageaccount'
+//!   location: 'westeurope'
+//!   sku: {
+//!     name: 'Standard_LRS'
+//!   }
+//!   kind: 'StorageV2'
+//! }
+//! ";
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(tree_sitter_bicep::language()).expect("Error loading Bicep grammar");
+//! parser.set_language(&tree_sitter_bicep::language()).expect("Error loading Bicep grammar");
 //! let tree = parser.parse(code, None).unwrap();
+//! assert!(!tree.root_node().has_error());
 //! ```
 //!
 //! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
@@ -57,7 +67,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(super::language())
+            .set_language(&super::language())
             .expect("Error loading Bicep grammar");
     }
 }


### PR DESCRIPTION
- this makes it compatible with the new `tree-sitter` version
- also aligned the code closer to the other grammars